### PR TITLE
Refactor Docker setup to utilize environment variable for API base URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,10 +4,12 @@ services:
     build:
       context: ./loumo-ui
       dockerfile: Dockerfile
+      args:
+        NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL}
     restart: unless-stopped
     # command: sh -c "npm install && npm run build && npm run start"
     environment:
-      NEXT_PUBLIC_API_BASE_URL: "https://api.loumoshop.com/api"
+      NEXT_PUBLIC_API_BASE_URL: ${NEXT_PUBLIC_API_BASE_URL}
     ports:
       - "3000:3000"
     networks:

--- a/loumo-ui/Dockerfile
+++ b/loumo-ui/Dockerfile
@@ -11,6 +11,9 @@ RUN npm ci
 # Copy app source code
 COPY . .
 
+ARG NEXT_PUBLIC_API_BASE_URL
+ENV NEXT_PUBLIC_API_BASE_URL=$NEXT_PUBLIC_API_BASE_URL
+
 # Build Next.js app (generates .next folder)
 RUN npm run build
 

--- a/loumo-ui/providers/axios.ts
+++ b/loumo-ui/providers/axios.ts
@@ -2,11 +2,8 @@
 import axios, { AxiosError, AxiosResponse } from "axios";
 import { toast } from "react-toastify";
 
-const baseURL =
-  process.env.NEXT_PUBLIC_API_BASE_URL;
-
 const api = axios.create({
-  baseURL,
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
   timeout: 10000,
   headers: {
     "Content-Type": "application/json",


### PR DESCRIPTION
- Updated docker-compose.yml to pass NEXT_PUBLIC_API_BASE_URL as a build argument and environment variable.
- Modified Dockerfile to set NEXT_PUBLIC_API_BASE_URL from build arguments.
- Adjusted axios configuration to directly use the environment variable for base URL.